### PR TITLE
Adding Approximate PCA tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+build/
 
 # Scala-IDE specific
 .idea*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
-build/
 
 # Scala-IDE specific
 .idea*


### PR DESCRIPTION
I've added a few tests to the pca-nodes branch.

I think these should be enough to capture that
1. The sketch algorithm used by the approximate PCA is correct.
2. The net effect we want to capture here (diagonal covariance on dimensionality reduced data) is preserved.
